### PR TITLE
Add module name to per-app logs

### DIFF
--- a/include/build-source-flatpak.sh
+++ b/include/build-source-flatpak.sh
@@ -303,7 +303,7 @@ function buildInstallFlatpakApps() {
 	rm -rf ${app_dir}
 	if [ ! -z "${build_source_logdir}" ]; then
 	    flatpak-builder "${args[@]}" --subject="Nightly build of ${app_id}, `date`" \
-                            ${app_dir} $file > "${build_source_logdir}/build-${app_id}-${build_source_arch}.txt" 2>&1
+                            ${app_dir} $file > "${build_source_logdir}/build-${module}-${app_id}-${build_source_arch}.txt" 2>&1
 	else
 	    flatpak-builder "${args[@]}" --subject="Nightly build of ${app_id}, `date`" \
                             ${app_dir} $file


### PR DESCRIPTION
Without this you cannot tell e.g. master and gnome-3-20 branch
builds from each other.
