### PR TITLE
Update git.gnome.org URLs to gitlab.gnome.org

### DIFF
--- a/build.conf
+++ b/build.conf
@@ -126,7 +126,7 @@ BASE_SDK_IRC_TARGETS['freedesktop-sdk-base']='flatpak flatpak-builds'
 # gnome-sdk-images 3.28 config
 #
 SDK_LIST+=('gnome-sdk-images')
-SDK_REPO['gnome-sdk-images']="git://git.gnome.org/gnome-sdk-images"
+SDK_REPO['gnome-sdk-images']="https://gitlab.gnome.org/GNOME/gnome-sdk-images.git"
 SDK_BRANCH['gnome-sdk-images']="gnome-3-28"
 SDK_VERSION['gnome-sdk-images']=3.28
 SDK_ASSETS['gnome-sdk-images']="org.gnome.Platform.Locale \
@@ -161,7 +161,7 @@ SDK_IRC_TARGETS['gnome-sdk-images-master']='flatpak flatpak-builds'
 # gnome-apps-nightly config
 #
 APP_LIST+=('gnome-apps-nightly')
-APP_REPO['gnome-apps-nightly']="git://git.gnome.org/gnome-apps-nightly"
+APP_REPO['gnome-apps-nightly']="https://gitlab.gnome.org/GNOME/gnome-apps-nightly.git"
 APP_BRANCH['gnome-apps-nightly']="stable"
 APP_BUILDER_ARGS['gnome-apps-nightly']=
 APP_IRC_TARGETS['gnome-apps-nightly']='flatpak flatpak-builds'


### PR DESCRIPTION
@alexlarsson the GNOME SDK build is currently broken:

```
====================================================
Starting build at Sat Jun  2 15:00:03 UTC 2018
====================================================


Looking for updates...
GLib-GIO-Message: Using the 'memory' GSettings backend.  Your settings will not be saved or shared with other applications.
Looking for updates...
Warning: Can't find dependencies: No flatpak cache in remote summary
Warning: Can't find dependencies: No flatpak cache in remote summary
Warning: Can't find dependencies: No flatpak cache in remote summary
Warning: Can't find dependencies: No flatpak cache in remote summary
Warning: Can't find dependencies: No flatpak cache in remote summary
Warning: Can't find dependencies: No flatpak cache in remote summary
Looking for updates...
GLib-GIO-Message: Using the 'memory' GSettings backend.  Your settings will not be saved or shared with other applications.
Looking for updates...
Warning: Can't find dependencies: No flatpak cache in remote summary
Warning: Can't find dependencies: No flatpak cache in remote summary
Warning: Can't find dependencies: No flatpak cache in remote summary
Warning: Can't find dependencies: No flatpak cache in remote summary
Warning: Can't find dependencies: No flatpak cache in remote summary
Warning: Can't find dependencies: No flatpak cache in remote summary
Fetching from https://github.com/flatpak/freedesktop-sdk-base.git
Cleared directory 'yocto'
Submodule 'yocto' (http://git.yoctoproject.org/git/poky) unregistered for path 'yocto'
Already on '1.6'
From https://github.com/flatpak/freedesktop-sdk-base
 * branch            1.6        -> FETCH_HEAD
Already up-to-date.
Submodule 'yocto' (http://git.yoctoproject.org/git/poky) registered for path 'yocto'
Submodule path 'yocto': checked out 'e6aadcc2a04ae4e85b1cb00c5c9ce1c0f76ee871'
Module freedesktop-sdk-base-1-6 is up to date, not rebuilding
Fetching from https://gitlab.gnome.org/GNOME/gnome-sdk-images.git
Already on 'master'
From https://gitlab.gnome.org/GNOME/gnome-sdk-images
 * branch            master     -> FETCH_HEAD
Already up-to-date.
Module gnome-sdk-images-master is up to date, not rebuilding
Fetching from git://git.gnome.org/gnome-apps-nightly
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Build of gnome-apps-nightly-master failed: Failed to fetch from 'git://git.gnome.org/gnome-apps-nightly'
====================================================
Build failed in: 0 days 00 hours 00 minutes 35 seconds
====================================================
```

I'm guessing this might help fix it....