### PR TITLE
Update the Sdks config

### DIFF
--- a/build.conf
+++ b/build.conf
@@ -48,6 +48,15 @@ BASE_DEP_REFS['freedesktop.org/18.08']="org.freedesktop.Platform.Locale//18.08 \
                                       org.freedesktop.Sdk.Debug//18.08 \
                                       org.freedesktop.Sdk.Docs//18.08"
 
+BASE_DEP_LIST+=('gnome/3.30')
+BASE_DEP_REMOTE['gnome/3.30']="flathub"
+BASE_DEP_REFS['gnome/3.30']="org.gnome.Platform//3.30 \
+                                      org.gnome.Platform.Locale//3.30 \
+                                      org.gnome.Sdk//3.30 \
+                                      org.gnome.Sdk.Debug//3.30 \
+                                      org.gnome.Sdk.Docs//3.30 \
+                                      org.gnome.Sdk.Locale//3.30"
+
 BASE_DEP_LIST+=('gnome/master')
 BASE_DEP_REMOTE['gnome/master']="gnome-build-meta"
 BASE_DEP_REFS['gnome/master']="org.gnome.Platform//master \

--- a/build.conf
+++ b/build.conf
@@ -35,6 +35,10 @@ REMOTES_LIST+=('flathub')
 REMOTES_FLATPAKREPO['flathub']="https://flathub.org/repo/flathub.flatpakrepo"
 REMOTES_ARGS['flathub']=""
 
+REMOTES_LIST+=('gnome-build-meta')
+REMOTES_FLATPAKREPO['gnome-build-meta']="https://gbm.gnome.org/gbm-nightly.flatpakrepo"
+REMOTES_ARGS['gnome-build-meta']=""
+
 BASE_DEP_LIST+=('freedesktop.org/18.08')
 BASE_DEP_REMOTE['freedesktop.org/18.08']="flathub"
 BASE_DEP_REFS['freedesktop.org/18.08']="org.freedesktop.Platform.Locale//18.08 \
@@ -44,6 +48,14 @@ BASE_DEP_REFS['freedesktop.org/18.08']="org.freedesktop.Platform.Locale//18.08 \
                                       org.freedesktop.Sdk.Debug//18.08 \
                                       org.freedesktop.Sdk.Docs//18.08"
 
+BASE_DEP_LIST+=('gnome/master')
+BASE_DEP_REMOTE['gnome/master']="gnome-build-meta"
+BASE_DEP_REFS['gnome/master']="org.gnome.Platform//master \
+                                      org.gnome.Platform.Locale//master \
+                                      org.gnome.Sdk//master \
+                                      org.gnome.Sdk.Debug//master \
+                                      org.gnome.Sdk.Docs//master \
+                                      org.gnome.Sdk.Locale//master"
 
 ##########################################################
 #              Build Payload Configurations              #
@@ -90,25 +102,6 @@ BASE_DEP_REFS['freedesktop.org/18.08']="org.freedesktop.Platform.Locale//18.08 \
 # configuration file, e.g:
 #
 #   SDK_IRC_TARGETS['foo']='foo foo-builds'
-
-
-################################
-#         Runtimes/SDKs        #
-################################
-#
-# gnome-sdk-images master config
-#
-SDK_LIST+=('gnome-sdk-images-master')
-SDK_REPO['gnome-sdk-images-master']="https://gitlab.gnome.org/GNOME/gnome-sdk-images.git"
-SDK_REPO_SUFFIX['gnome-sdk-images-master']="-nightly"
-SDK_BRANCH['gnome-sdk-images-master']="master"
-SDK_VERSION['gnome-sdk-images-master']=master
-SDK_ASSETS['gnome-sdk-images-master']="org.gnome.Platform.Locale \
-                                org.gnome.Platform \
-                                org.gnome.Sdk.Locale \
-                                org.gnome.Sdk \
-                                org.gnome.Sdk.Debug"
-SDK_IRC_TARGETS['gnome-sdk-images-master']='flatpak flatpak-builds'
 
 
 ################################

--- a/build.conf
+++ b/build.conf
@@ -35,15 +35,6 @@ REMOTES_LIST+=('flathub')
 REMOTES_FLATPAKREPO['flathub']="https://flathub.org/repo/flathub.flatpakrepo"
 REMOTES_ARGS['flathub']=""
 
-BASE_DEP_LIST+=('freedesktop.org/1.6')
-BASE_DEP_REMOTE['freedesktop.org/1.6']="flathub"
-BASE_DEP_REFS['freedesktop.org/1.6']="org.freedesktop.Platform.Locale//1.6 \
-                                      org.freedesktop.Platform//1.6 \
-                                      org.freedesktop.Sdk.Locale//1.6 \
-                                      org.freedesktop.Sdk//1.6 \
-                                      org.freedesktop.Sdk.Debug//1.6 \
-                                      org.freedesktop.Sdk.Docs//1.6"
-
 BASE_DEP_LIST+=('freedesktop.org/18.08')
 BASE_DEP_REMOTE['freedesktop.org/18.08']="flathub"
 BASE_DEP_REFS['freedesktop.org/18.08']="org.freedesktop.Platform.Locale//18.08 \


### PR DESCRIPTION
Nothing built here still requires org.freedesktop.Sdk//1.6, so there's no need to keep pulling it from flathub.

Some apps need the latest stable GNOME Sdk, so let's start pulling it from Flathub.

Finally, we do not need to build the GNOME master Sdk any more: we can just pull it from the new GNOME Build Meta repository.

This effectively deprecates gnome-sdk-images. :tada: