### PR TITLE
config: Pull the FDO Sdk Rust extension

### DIFF
--- a/build.conf
+++ b/build.conf
@@ -46,7 +46,8 @@ BASE_DEP_REFS['freedesktop.org/18.08']="org.freedesktop.Platform.Locale//18.08 \
                                       org.freedesktop.Sdk.Locale//18.08 \
                                       org.freedesktop.Sdk//18.08 \
                                       org.freedesktop.Sdk.Debug//18.08 \
-                                      org.freedesktop.Sdk.Docs//18.08"
+                                      org.freedesktop.Sdk.Docs//18.08 \
+                                      org.freedesktop.Sdk.Extension.rust-stable//18.08"
 
 BASE_DEP_LIST+=('gnome/3.30')
 BASE_DEP_REMOTE['gnome/3.30']="flathub"


### PR DESCRIPTION
This is required to build some applications like Fractal or Podcasts.