### PR TITLE
Update ostree, flatpak and flatpak-builder

### DIFF
--- a/build-setup.sh
+++ b/build-setup.sh
@@ -163,7 +163,7 @@ function refreshTools() {
     #
     buildSourceAdd "ostree"     "https://github.com/ostreedev/ostree"    "v2019.1" buildInstallAutotools
     buildSourceAdd "flatpak"    "https://github.com/flatpak/flatpak.git" "1.2.2" buildInstallAutotools
-    buildSourceAdd "flatpak-builder"    "https://github.com/flatpak/flatpak-builder.git" "1.0.4" buildInstallAutotools
+    buildSourceAdd "flatpak-builder"    "https://github.com/flatpak/flatpak-builder.git" "1.0.5" buildInstallAutotools
 
     buildSourceRun
 }


### PR DESCRIPTION
In particular, f-b is required to get Totem to build again.